### PR TITLE
docs: Add Tailscale access section with resetOnExit warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,18 @@ nvm install 22
 cd ~/.openclaw/workspace
 git clone https://github.com/madrzak/vidclaw.git dashboard
 
-# Run the setup script (installs deps, builds, sets up systemd)
+# Run the setup script (installs deps, builds, sets up systemd/launchd)
 cd dashboard
 ./setup.sh
+
+# Or with Tailscale Serve integration (optional, default port 8443)
+./setup.sh --tailscale
+./setup.sh --tailscale 9443  # custom port
 ```
 
-That's it. The setup script handles everything — npm install, frontend build, systemd service creation, and starts the dashboard automatically.
+That's it. The setup script handles everything — npm install, frontend build, service creation (systemd on Linux, launchd on macOS), and starts the dashboard automatically.
+
+When `--tailscale` is passed, the service is configured to register its Tailscale Serve route on every start, so the route survives OpenClaw gateway restarts with `resetOnExit: true`.
 
 Access via SSH tunnel:
 ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -49,12 +49,75 @@ mkdir -p "$DASHBOARD_DIR/data"
 # Detect OS
 OS="$(uname -s)"
 
+# Resolve tailscale binary path (if needed)
+if [ "$TAILSCALE_ENABLED" = "true" ]; then
+  TAILSCALE_BIN=$(which tailscale 2>/dev/null || echo "")
+  if [ -z "$TAILSCALE_BIN" ]; then
+    echo "❌ --tailscale requested but 'tailscale' not found in PATH."
+    exit 1
+  fi
+  echo "🔗 Tailscale integration enabled (port $TAILSCALE_PORT)"
+fi
+
 if [ "$OS" = "Darwin" ]; then
   # macOS: install launchd plist
   echo "⚙️  Installing launchd service..."
   PLIST_PATH="$HOME/Library/LaunchAgents/com.vidclaw.plist"
   mkdir -p "$HOME/Library/LaunchAgents"
-  cat > "$PLIST_PATH" << EOF
+
+  if [ "$TAILSCALE_ENABLED" = "true" ]; then
+    # Create a wrapper script that registers the Tailscale Serve route
+    # before starting the node server. This ensures the route is
+    # re-registered on every launch (survives OpenClaw resetOnExit).
+    WRAPPER="$DASHBOARD_DIR/start-vidclaw.sh"
+    cat > "$WRAPPER" << WRAPPER_EOF
+#!/bin/bash
+# Re-register Tailscale Serve route (idempotent — safe to run on every start).
+# The leading '-' equivalent: we don't exit on failure so the server still starts.
+$TAILSCALE_BIN serve --bg --https=$TAILSCALE_PORT http://127.0.0.1:3333 || true
+exec $NODE_BIN $DASHBOARD_DIR/server.js
+WRAPPER_EOF
+    chmod +x "$WRAPPER"
+    LAUNCH_CMD="$WRAPPER"
+  else
+    LAUNCH_CMD=""
+  fi
+
+  if [ -n "$LAUNCH_CMD" ]; then
+    # Use wrapper script as single program argument
+    cat > "$PLIST_PATH" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.vidclaw</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$LAUNCH_CMD</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$DASHBOARD_DIR</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>NODE_ENV</key>
+    <string>production</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$DASHBOARD_DIR/data/vidclaw.log</string>
+  <key>StandardErrorPath</key>
+  <string>$DASHBOARD_DIR/data/vidclaw.err</string>
+</dict>
+</plist>
+EOF
+  else
+    cat > "$PLIST_PATH" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -86,6 +149,7 @@ if [ "$OS" = "Darwin" ]; then
 </dict>
 </plist>
 EOF
+  fi
 
   # Unload first if already loaded (ignore errors)
   launchctl unload "$PLIST_PATH" 2>/dev/null || true
@@ -93,6 +157,7 @@ EOF
 else
   # Linux: install systemd service
   echo "⚙️  Installing systemd service..."
+
   sudo tee /etc/systemd/system/vidclaw.service > /dev/null << EOF
 [Unit]
 Description=VidClaw
@@ -109,6 +174,14 @@ Environment=NODE_ENV=production
 [Install]
 WantedBy=multi-user.target
 EOF
+
+  # Inject ExecStartPre for Tailscale Serve if enabled.
+  # The leading '-' tells systemd to continue even if this command fails,
+  # so the server still starts if tailscale is temporarily unavailable.
+  if [ "$TAILSCALE_ENABLED" = "true" ]; then
+    sudo sed -i "/^ExecStart=/i ExecStartPre=-$TAILSCALE_BIN serve --bg --https=$TAILSCALE_PORT http://127.0.0.1:3333" \
+      /etc/systemd/system/vidclaw.service
+  fi
 
   sudo systemctl daemon-reload
   sudo systemctl enable --now vidclaw
@@ -141,6 +214,11 @@ echo ""
 echo "✅ Dashboard installed and running!"
 echo ""
 echo "   Local:  http://localhost:3333"
+
+if [ "$TAILSCALE_ENABLED" = "true" ]; then
+  TS_HOSTNAME=$(tailscale status --json 2>/dev/null | python3 -c "import json,sys;print(json.load(sys.stdin)['Self']['DNSName'].rstrip('.'))" 2>/dev/null || echo "your-machine.your-tailnet.ts.net")
+  echo "   Tailscale: https://${TS_HOSTNAME}:${TAILSCALE_PORT}/"
+fi
 
 if [ "$OS" = "Darwin" ]; then
   echo "   Remote: ssh -L 3333:localhost:3333 $(whoami)@$(hostname | head -1)"


### PR DESCRIPTION
Adds a Tailscale Serve subsection to the Security section for users who prefer Tailscale over SSH tunnels.

Includes a warning about OpenClaw's `tailscale.resetOnExit: true` config option, which tears down *all* Tailscale Serve rules on gateway stop — silently breaking VidClaw's route on every restart. Documents the fix (re-register the serve route on startup via systemd/launchd).