### PR TITLE
feat: File browser sorting and richer metadata (#12)

### DIFF
--- a/server/controllers/files.js
+++ b/server/controllers/files.js
@@ -14,7 +14,16 @@ export function listFiles(req, res) {
         if (reqPath === 'dashboard' && e.name === 'node_modules') return false;
         return true;
       })
-      .map(e => ({ name: e.name, isDirectory: e.isDirectory(), path: path.join(reqPath, e.name) }))
+      .map(e => {
+        const entryPath = path.join(fullPath, e.name);
+        let size = 0, mtime = null;
+        try {
+          const stat = fs.statSync(entryPath);
+          size = stat.size;
+          mtime = stat.mtime.toISOString();
+        } catch {}
+        return { name: e.name, isDirectory: e.isDirectory(), path: path.join(reqPath, e.name), size, mtime };
+      })
       .sort((a, b) => b.isDirectory - a.isDirectory || a.name.localeCompare(b.name));
     res.json(entries);
   } catch { res.json([]); }

--- a/src/components/Content/FileBrowser.jsx
+++ b/src/components/Content/FileBrowser.jsx
@@ -1,12 +1,60 @@
-import React, { useState, useEffect } from 'react'
-import { Folder, File, ChevronRight, ArrowLeft, Download, Eye } from 'lucide-react'
+import React, { useState, useEffect, useMemo } from 'react'
+import { Folder, File, ChevronRight, ArrowLeft, Download, Eye, ArrowUpDown, FileText, FileImage, FileVideo, FileAudio, FileCode, FileArchive } from 'lucide-react'
 import FilePreview from './FilePreview'
 import { cn } from '@/lib/utils'
+
+const SORT_OPTIONS = [
+  { value: 'name-asc', label: 'Name A→Z' },
+  { value: 'name-desc', label: 'Name Z→A' },
+  { value: 'date-desc', label: 'Newest first' },
+  { value: 'date-asc', label: 'Oldest first' },
+  { value: 'size-desc', label: 'Largest first' },
+  { value: 'size-asc', label: 'Smallest first' },
+]
+
+function getFileIcon(name) {
+  const ext = name.split('.').pop()?.toLowerCase()
+  const imageExts = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp', 'ico']
+  const videoExts = ['mp4', 'mkv', 'avi', 'mov', 'webm', 'flv']
+  const audioExts = ['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a']
+  const codeExts = ['js', 'jsx', 'ts', 'tsx', 'py', 'rb', 'go', 'rs', 'c', 'cpp', 'h', 'java', 'sh', 'bash', 'css', 'scss', 'html', 'vue', 'svelte']
+  const archiveExts = ['zip', 'tar', 'gz', 'bz2', 'xz', 'rar', '7z']
+  const docExts = ['md', 'txt', 'pdf', 'doc', 'docx', 'rtf', 'csv', 'json', 'yaml', 'yml', 'xml', 'toml']
+
+  if (imageExts.includes(ext)) return <FileImage size={16} className="text-emerald-400 shrink-0" />
+  if (videoExts.includes(ext)) return <FileVideo size={16} className="text-purple-400 shrink-0" />
+  if (audioExts.includes(ext)) return <FileAudio size={16} className="text-pink-400 shrink-0" />
+  if (codeExts.includes(ext)) return <FileCode size={16} className="text-blue-400 shrink-0" />
+  if (archiveExts.includes(ext)) return <FileArchive size={16} className="text-orange-400 shrink-0" />
+  if (docExts.includes(ext)) return <FileText size={16} className="text-sky-400 shrink-0" />
+  return <File size={16} className="text-muted-foreground shrink-0" />
+}
+
+function formatSize(bytes) {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  const val = bytes / Math.pow(1024, i)
+  return `${val < 10 ? val.toFixed(1) : Math.round(val)} ${units[i]}`
+}
+
+function formatDate(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  const now = new Date()
+  const diff = now - d
+  if (diff < 60000) return 'just now'
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`
+  if (diff < 604800000) return `${Math.floor(diff / 86400000)}d ago`
+  return d.toLocaleDateString('en-IE', { day: 'numeric', month: 'short', year: d.getFullYear() !== now.getFullYear() ? 'numeric' : undefined })
+}
 
 export default function FileBrowser() {
   const [currentPath, setCurrentPath] = useState('')
   const [entries, setEntries] = useState([])
   const [preview, setPreview] = useState(null)
+  const [sortBy, setSortBy] = useState('name-asc')
 
   useEffect(() => {
     fetch(`/api/files?path=${encodeURIComponent(currentPath)}`)
@@ -14,6 +62,22 @@ export default function FileBrowser() {
       .then(setEntries)
       .catch(() => setEntries([]))
   }, [currentPath])
+
+  const sortedEntries = useMemo(() => {
+    const dirs = entries.filter(e => e.isDirectory)
+    const files = entries.filter(e => !e.isDirectory)
+    const [field, dir] = sortBy.split('-')
+    const mul = dir === 'asc' ? 1 : -1
+
+    const sorter = (a, b) => {
+      if (field === 'name') return mul * a.name.localeCompare(b.name)
+      if (field === 'date') return mul * ((a.mtime || '').localeCompare(b.mtime || ''))
+      if (field === 'size') return mul * ((a.size || 0) - (b.size || 0))
+      return 0
+    }
+
+    return [...dirs.sort(sorter), ...files.sort(sorter)]
+  }, [entries, sortBy])
 
   function navigate(entry) {
     if (entry.isDirectory) {
@@ -54,9 +118,21 @@ export default function FileBrowser() {
               </button>
             </React.Fragment>
           ))}
+          <div className="ml-auto flex items-center gap-1">
+            <ArrowUpDown size={14} className="text-muted-foreground" />
+            <select
+              value={sortBy}
+              onChange={e => setSortBy(e.target.value)}
+              className="bg-transparent text-xs text-muted-foreground hover:text-foreground border-none outline-none cursor-pointer"
+            >
+              {SORT_OPTIONS.map(o => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
         </div>
         <div className="flex-1 overflow-y-auto divide-y divide-border">
-          {entries.map(entry => (
+          {sortedEntries.map(entry => (
             <div
               key={entry.path}
               className="flex items-center gap-3 px-3 py-2 hover:bg-accent/50 cursor-pointer transition-colors group"
@@ -65,9 +141,18 @@ export default function FileBrowser() {
               {entry.isDirectory ? (
                 <Folder size={16} className="text-amber-400 shrink-0" />
               ) : (
-                <File size={16} className="text-muted-foreground shrink-0" />
+                getFileIcon(entry.name)
               )}
               <span className="text-sm flex-1 truncate">{entry.name}</span>
+              <span className="text-xs text-muted-foreground hidden sm:inline whitespace-nowrap">
+                {entry.mtime ? formatDate(entry.mtime) : ''}
+              </span>
+              {!entry.isDirectory && (
+                <span className="text-xs text-muted-foreground hidden sm:inline whitespace-nowrap w-16 text-right">
+                  {formatSize(entry.size || 0)}
+                </span>
+              )}
+              {entry.isDirectory && <span className="w-16 hidden sm:inline" />}
               {!entry.isDirectory && (
                 <a
                   href={`/api/files/download?path=${encodeURIComponent(entry.path)}`}


### PR DESCRIPTION
## Changes

- **Sorting controls**: Dropdown in the breadcrumb bar with 6 sort modes — name (A→Z / Z→A), date (newest/oldest first), size (largest/smallest first). Directories always sort before files.
- **File metadata**: Each entry now shows relative last-modified time and file size.
- **File type icons**: Context-aware icons for images, video, audio, code, archives, and documents (via lucide-react).
- **Server update**: `/api/files` now returns `size` and `mtime` fields.

Closes #12