### PR TITLE
feat: add dark/light theme toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,23 +7,26 @@ import SkillsManager from './components/Skills/SkillsManager'
 import SoulEditor from './components/Soul/SoulEditor'
 import SettingsPage from './components/Settings/SettingsPage'
 import { TimezoneProvider } from './components/TimezoneContext'
+import { ThemeProvider } from './components/ThemeContext'
 import { SocketProvider } from './hooks/useSocket.jsx'
 
 export default function App() {
   const [page, setPage] = useState('kanban')
 
   return (
-    <SocketProvider>
-      <TimezoneProvider>
-        <Layout page={page} setPage={setPage}>
-          {page === 'kanban' && <Board />}
-          {page === 'calendar' && <CalendarView />}
-          {page === 'files' && <FileBrowser />}
-          {page === 'skills' && <SkillsManager />}
-          {page === 'soul' && <SoulEditor />}
-          {page === 'settings' && <SettingsPage />}
-        </Layout>
-      </TimezoneProvider>
-    </SocketProvider>
+    <ThemeProvider>
+      <SocketProvider>
+        <TimezoneProvider>
+          <Layout page={page} setPage={setPage}>
+            {page === 'kanban' && <Board />}
+            {page === 'calendar' && <CalendarView />}
+            {page === 'files' && <FileBrowser />}
+            {page === 'skills' && <SkillsManager />}
+            {page === 'soul' && <SoulEditor />}
+            {page === 'settings' && <SettingsPage />}
+          </Layout>
+        </TimezoneProvider>
+      </SocketProvider>
+    </ThemeProvider>
   )
 }

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react'
 import { cn } from '@/lib/utils'
 import UsageWidget from './Usage/UsageWidget'
-import { LayoutDashboard, Calendar, FolderOpen, Puzzle, Heart, Settings, Menu, X, Coffee } from 'lucide-react'
+import { LayoutDashboard, Calendar, FolderOpen, Puzzle, Heart, Settings, Menu, X, Coffee, Sun, Moon } from 'lucide-react'
+import { useTheme } from './ThemeContext'
 
 const navItems = [
   { id: 'kanban', label: 'Tasks', icon: LayoutDashboard },
@@ -14,6 +15,7 @@ const navItems = [
 
 export default function Layout({ page, setPage, children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const { theme, toggleTheme } = useTheme()
 
   // Close sidebar on page change (mobile)
   useEffect(() => {
@@ -93,6 +95,13 @@ export default function Layout({ page, setPage, children }) {
             <span className="text-sm font-medium capitalize">{page === 'kanban' ? 'Task Board' : page === 'calendar' ? 'Activity Calendar' : page === 'skills' ? 'Skills Manager' : page === 'soul' ? 'Soul Editor' : page === 'settings' ? 'Settings' : 'Content Browser'}</span>
           </div>
           <div className="flex items-center gap-3">
+            <button
+              onClick={toggleTheme}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
+            </button>
             <a
               href="https://buy.stripe.com/8x2aEX0Wl7Wv7Roag9cEw0f"
               target="_blank"

--- a/src/components/ThemeContext.jsx
+++ b/src/components/ThemeContext.jsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+const ThemeContext = createContext()
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('vidclaw-theme') || 
+        (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+    }
+    return 'dark'
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    root.classList.remove('light', 'dark')
+    root.classList.add(theme)
+    localStorage.setItem('vidclaw-theme', theme)
+  }, [theme])
+
+  const toggleTheme = () => setTheme(t => t === 'dark' ? 'light' : 'dark')
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => useContext(ThemeContext)


### PR DESCRIPTION
## Changes

- Add ThemeContext with localStorage persistence and system preference detection
- Add Sun/Moon toggle button in Layout header
- Wrap app with ThemeProvider
- Uses existing CSS vars and Tailwind darkMode class strategy

Preference stored as `vidclaw-theme` in localStorage. Falls back to system `prefers-color-scheme` on first visit.