### PR TITLE
fix: mobile horizontal overflow on landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@
       --accent-glow: rgba(249, 115, 22, 0.15);
     }
 
-    body {
+    html, body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
       color: var(--text);
@@ -42,6 +42,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      overflow: hidden;
       justify-content: center;
       text-align: center;
       padding: 2rem;


### PR DESCRIPTION
The landing page had a horizontal scrollbar on mobile caused by:

1. **`.hero::before` glow** — 800px fixed-width radial gradient spilling past the viewport
2. **`body` overflow-x alone insufficient** — some browsers need it on `html` too

### Changes
- Added `overflow: hidden` to `.hero` to contain the glow effect
- Applied `overflow-x: hidden` to `html` element alongside `body`

Two-line fix. No visual changes on desktop.