### PR TITLE
feat: Add Clear All button for Todo column

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -5,7 +5,7 @@ import { __dirname } from './config.js';
 import { getActivity, getTime } from './controllers/activity.js';
 import {
   listTasks, createTask, updateTask, reorderTasks,
-  runTask, getTaskQueue, pickupTask, completeTask, deleteTask,
+  runTask, getTaskQueue, pickupTask, completeTask, deleteTask, bulkDeleteTasks,
   getCalendar, getRunHistory, toggleSchedule,
 } from './controllers/tasks.js';
 import { getUsage } from './controllers/usage.js';
@@ -35,6 +35,7 @@ router.post('/api/tasks/:id/complete', completeTask);
 router.get('/api/tasks/:id/history', getRunHistory);
 router.post('/api/tasks/:id/schedule-toggle', toggleSchedule);
 router.delete('/api/tasks/:id', deleteTask);
+router.post('/api/tasks/bulk-delete', bulkDeleteTasks);
 router.get('/api/calendar', getCalendar);
 
 // Usage

--- a/src/components/Kanban/Board.jsx
+++ b/src/components/Kanban/Board.jsx
@@ -182,6 +182,15 @@ export default function Board() {
     fetchTasks()
   }
 
+  async function handleBulkDelete(status) {
+    await fetch('/api/tasks/bulk-delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    })
+    fetchTasks()
+  }
+
   async function handleQuickAdd(status, title, skills = []) {
     await fetch('/api/tasks', {
       method: 'POST',
@@ -222,6 +231,7 @@ export default function Board() {
               onDelete={handleDelete}
               onRun={handleRun}
               onToggleSchedule={handleToggleSchedule}
+              onBulkDelete={handleBulkDelete}
             />
           ))}
         </div>

--- a/src/components/Kanban/Column.jsx
+++ b/src/components/Kanban/Column.jsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react'
 import { useDroppable } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import TaskCard from './TaskCard'
-import { Plus, X } from 'lucide-react'
+import { Plus, X, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import HeartbeatTimer from '../Usage/HeartbeatTimer'
 
@@ -144,7 +144,7 @@ function SkillAutosuggest({ inputRef, title, setTitle, onSubmit, skills }) {
   )
 }
 
-export default function Column({ column, tasks, onAdd, onQuickAdd, onEdit, onView, onDelete, onRun, onToggleSchedule }) {
+export default function Column({ column, tasks, onAdd, onQuickAdd, onEdit, onView, onDelete, onRun, onToggleSchedule, onBulkDelete }) {
   const { setNodeRef, isOver } = useDroppable({ id: column.id })
   const [adding, setAdding] = useState(false)
   const [title, setTitle] = useState('')
@@ -186,7 +186,22 @@ export default function Column({ column, tasks, onAdd, onQuickAdd, onEdit, onVie
           <span className="text-sm font-medium">{column.title}</span>
           <span className="text-xs text-muted-foreground bg-secondary rounded-full px-1.5">{tasks.length}</span>
         </div>
-        {column.id === 'todo' && <HeartbeatTimer />}
+        <div className="flex items-center gap-1">
+          {column.id === 'todo' && tasks.length > 0 && (
+            <button
+              onClick={() => {
+                if (window.confirm(`Delete all ${tasks.length} task(s) in ${column.title}?`)) {
+                  onBulkDelete?.(column.id)
+                }
+              }}
+              className="text-muted-foreground hover:text-destructive transition-colors p-0.5 rounded"
+              title="Clear all todo tasks"
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
+          {column.id === 'todo' && <HeartbeatTimer />}
+        </div>
       </div>
       <div className="flex-1 overflow-y-auto p-2 space-y-2 min-h-[120px]">
         <SortableContext items={taskIds} strategy={verticalListSortingStrategy}>


### PR DESCRIPTION
## Summary

Adds a "Clear All" button (trash icon) to the Todo column header that bulk-deletes all tasks in the Todo column after a confirmation dialog.

### Changes

**Backend:**
- New `POST /api/tasks/bulk-delete` endpoint accepting `{ status }` or `{ ids[] }` to delete tasks in bulk
- Logs each deletion to activity
- Broadcasts updated task list via WebSocket

**Frontend:**
- Trash icon in Todo column header (only visible when tasks exist)
- `window.confirm()` dialog before deleting
- Wired through `onBulkDelete` prop from Board → Column

Closes #26