### PR TITLE
Add /features, /docs, and /changelog SEO pages

### DIFF
--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Changelog - VidClaw | Self-Hosted AI Dashboard Updates</title>
+  <meta name="description" content="VidClaw changelog — latest updates, new features, and improvements to the self-hosted AI dashboard for OpenClaw agent management.">
+  <link rel="canonical" href="https://vidclaw.com/changelog">
+  <script async src="https://plausible.io/js/pa-GKT997euCDfQROHoFG713.js"></script>
+  <script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()</script>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root { --bg: #0a0a0f; --surface: #12121a; --border: #1e1e2e; --text: #e4e4e7; --muted: #71717a; --accent: #f97316; }
+    html, body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    nav { display: flex; align-items: center; justify-content: space-between; max-width: 1100px; margin: 0 auto; padding: 1.5rem 2rem; }
+    nav .brand { font-weight: 800; font-size: 1.2rem; color: var(--text); display: flex; align-items: center; gap: 0.5rem; }
+    nav .brand:hover { text-decoration: none; color: var(--accent); }
+    nav .nav-links { display: flex; gap: 1.5rem; font-size: 0.95rem; }
+    nav .nav-links a { color: var(--muted); }
+    nav .nav-links a:hover, nav .nav-links a.active { color: var(--accent); text-decoration: none; }
+
+    .page { max-width: 800px; margin: 0 auto; padding: 2rem 2rem 6rem; }
+    .page h1 { font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; margin-bottom: 1rem; background: linear-gradient(135deg, #f97316, #fbbf24); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+    .page .subtitle { color: var(--muted); font-size: 1.15rem; margin-bottom: 3rem; }
+    .page p, .page li { color: var(--muted); font-size: 1rem; margin-bottom: 0.75rem; }
+    .page p strong { color: var(--text); }
+    .page ul { padding-left: 1.5rem; margin-bottom: 1.5rem; }
+
+    .release { border-left: 2px solid var(--border); padding-left: 2rem; margin-bottom: 3rem; position: relative; }
+    .release::before { content: ''; position: absolute; left: -6px; top: 0.5rem; width: 10px; height: 10px; background: var(--accent); border-radius: 50%; }
+    .release h2 { font-size: 1.3rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .release .date { color: var(--muted); font-size: 0.85rem; margin-bottom: 1rem; }
+    .release .tag { display: inline-block; font-size: 0.75rem; font-weight: 600; padding: 0.15rem 0.6rem; border-radius: 100px; margin-left: 0.5rem; }
+    .tag-new { background: rgba(34, 197, 94, 0.15); color: #22c55e; }
+    .tag-improved { background: rgba(59, 130, 246, 0.15); color: #3b82f6; }
+    .tag-fix { background: rgba(239, 68, 68, 0.15); color: #ef4444; }
+
+    footer { text-align: center; padding: 3rem 2rem; color: var(--muted); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--accent); }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a href="/" class="brand">⚡ VidClaw</a>
+    <div class="nav-links">
+      <a href="/features">Features</a>
+      <a href="/docs">Docs</a>
+      <a href="/changelog" class="active">Changelog</a>
+      <a href="https://github.com/madrzak/vidclaw">GitHub</a>
+    </div>
+  </nav>
+
+  <div class="page">
+    <h1>Changelog</h1>
+    <p class="subtitle">All notable updates to VidClaw, the <a href="/features">self-hosted AI dashboard</a> for <a href="/docs">OpenClaw agent management</a>.</p>
+
+    <div class="release">
+      <h2>v1.5.0 <span class="tag tag-new">New</span></h2>
+      <div class="date">February 2025</div>
+      <ul>
+        <li>Added <strong>credentials manager</strong> for secure secret storage</li>
+        <li>New "Delete All Done" bulk action for the Kanban board</li>
+        <li>Improved task card display for completed items</li>
+        <li>Better memory management panel</li>
+      </ul>
+    </div>
+
+    <div class="release">
+      <h2>v1.4.0 <span class="tag tag-improved">Improved</span></h2>
+      <div class="date">January 2025</div>
+      <ul>
+        <li>SEO improvements — optimized <code>robots.txt</code> and <code>sitemap.xml</code></li>
+        <li>Optimized README for discoverability</li>
+        <li>Cross-platform setup script (Linux + macOS)</li>
+      </ul>
+    </div>
+
+    <div class="release">
+      <h2>v1.3.0 <span class="tag tag-new">New</span></h2>
+      <div class="date">December 2024</div>
+      <ul>
+        <li><strong>AI cost tracking</strong> panel with per-model breakdowns</li>
+        <li>Rate limit progress bars matching Anthropic's windows</li>
+        <li>Model switching from the navbar</li>
+        <li>Daily and monthly spending summaries</li>
+      </ul>
+    </div>
+
+    <div class="release">
+      <h2>v1.2.0 <span class="tag tag-new">New</span></h2>
+      <div class="date">November 2024</div>
+      <ul>
+        <li>Skills Manager — browse, enable, disable, and create skills</li>
+        <li>Soul Editor with version history and starter templates</li>
+        <li>Content browser with markdown preview</li>
+      </ul>
+    </div>
+
+    <div class="release">
+      <h2>v1.1.0 <span class="tag tag-improved">Improved</span></h2>
+      <div class="date">October 2024</div>
+      <ul>
+        <li>Activity calendar view parsed from memory files</li>
+        <li>Task priority levels (P1–P4)</li>
+        <li>Drag-and-drop improvements on mobile</li>
+      </ul>
+    </div>
+
+    <div class="release">
+      <h2>v1.0.0</h2>
+      <div class="date">September 2024</div>
+      <ul>
+        <li>Initial release of VidClaw</li>
+        <li>Kanban task board with four columns</li>
+        <li>Basic usage tracking</li>
+        <li>SSH tunnel security model</li>
+        <li>One-command setup via <code>setup.sh</code></li>
+      </ul>
+    </div>
+
+    <p style="text-align: center; margin-top: 3rem;">For the full commit history, see the <a href="https://github.com/madrzak/vidclaw/commits/main">GitHub commits</a>. Explore all <a href="/features">features</a> or read the <a href="/docs">setup guide</a>.</p>
+  </div>
+
+  <footer>
+    <p>Built by <a href="https://x.com/woocassh">woocassh</a> · <a href="https://github.com/madrzak/vidclaw">GitHub</a> · <a href="/features">Features</a> · <a href="/docs">Docs</a> · <a href="/changelog">Changelog</a> · MIT License</p>
+  </footer>
+
+</body>
+</html>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Documentation - VidClaw | Setup Guide for Your Self-Hosted AI Dashboard</title>
+  <meta name="description" content="Complete setup guide for VidClaw, the self-hosted AI dashboard for OpenClaw agent management. Install, configure, and start tracking AI costs in 60 seconds.">
+  <link rel="canonical" href="https://vidclaw.com/docs">
+  <script async src="https://plausible.io/js/pa-GKT997euCDfQROHoFG713.js"></script>
+  <script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()</script>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root { --bg: #0a0a0f; --surface: #12121a; --border: #1e1e2e; --text: #e4e4e7; --muted: #71717a; --accent: #f97316; }
+    html, body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    nav { display: flex; align-items: center; justify-content: space-between; max-width: 1100px; margin: 0 auto; padding: 1.5rem 2rem; }
+    nav .brand { font-weight: 800; font-size: 1.2rem; color: var(--text); display: flex; align-items: center; gap: 0.5rem; }
+    nav .brand:hover { text-decoration: none; color: var(--accent); }
+    nav .nav-links { display: flex; gap: 1.5rem; font-size: 0.95rem; }
+    nav .nav-links a { color: var(--muted); }
+    nav .nav-links a:hover, nav .nav-links a.active { color: var(--accent); text-decoration: none; }
+
+    .page { max-width: 800px; margin: 0 auto; padding: 2rem 2rem 6rem; }
+    .page h1 { font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; margin-bottom: 1rem; background: linear-gradient(135deg, #f97316, #fbbf24); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+    .page .subtitle { color: var(--muted); font-size: 1.15rem; margin-bottom: 3rem; }
+    .page h2 { font-size: 1.5rem; font-weight: 700; margin: 3rem 0 1rem; padding-top: 1rem; }
+    .page h3 { font-size: 1.15rem; font-weight: 600; margin: 1.5rem 0 0.5rem; }
+    .page p, .page li { color: var(--muted); font-size: 1rem; margin-bottom: 1rem; }
+    .page p strong { color: var(--text); }
+    .page ul, .page ol { padding-left: 1.5rem; margin-bottom: 1.5rem; }
+    .page li { margin-bottom: 0.5rem; }
+    .page code { background: var(--surface); border: 1px solid var(--border); padding: 0.15rem 0.4rem; border-radius: 4px; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.9rem; }
+
+    .code-block { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.5rem 2rem; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.9rem; color: var(--text); overflow-x: auto; margin-bottom: 1.5rem; }
+    .code-block .comment { color: var(--muted); }
+    .code-block .cmd { color: var(--accent); }
+
+    .step { counter-increment: step; position: relative; padding-left: 3rem; margin-bottom: 2.5rem; }
+    .step::before { content: counter(step); position: absolute; left: 0; top: 0; width: 2rem; height: 2rem; background: var(--accent); color: #fff; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 0.85rem; }
+    .steps { counter-reset: step; }
+
+    .note { background: var(--surface); border-left: 3px solid var(--accent); padding: 1rem 1.5rem; border-radius: 0 8px 8px 0; margin: 1.5rem 0; }
+    .note p { margin-bottom: 0; }
+
+    footer { text-align: center; padding: 3rem 2rem; color: var(--muted); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--accent); }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a href="/" class="brand">⚡ VidClaw</a>
+    <div class="nav-links">
+      <a href="/features">Features</a>
+      <a href="/docs" class="active">Docs</a>
+      <a href="/changelog">Changelog</a>
+      <a href="https://github.com/madrzak/vidclaw">GitHub</a>
+    </div>
+  </nav>
+
+  <div class="page">
+    <h1>Documentation</h1>
+    <p class="subtitle">Get your self-hosted AI dashboard up and running in under a minute. This guide covers installation, configuration, and daily usage.</p>
+
+    <h2>Prerequisites for Your Self-Hosted AI Dashboard</h2>
+    <p>Before installing VidClaw, make sure you have:</p>
+    <ul>
+      <li><strong>Node.js 18+</strong> installed on your server</li>
+      <li>A running <a href="https://github.com/openclaw/openclaw" target="_blank" rel="noopener">OpenClaw</a> instance</li>
+      <li>SSH access to your server (for the secure tunnel)</li>
+    </ul>
+
+    <h2>Quick Install — OpenClaw Agent Management Setup</h2>
+    <div class="steps">
+      <div class="step">
+        <h3>Clone the repository</h3>
+        <p>Clone VidClaw into your OpenClaw workspace:</p>
+        <div class="code-block">
+          <span class="cmd">cd</span> ~/.openclaw/workspace<br>
+          <span class="cmd">git clone</span> https://github.com/madrzak/vidclaw.git dashboard
+        </div>
+      </div>
+
+      <div class="step">
+        <h3>Run the setup script</h3>
+        <p>The setup script installs dependencies, builds the frontend, and creates a systemd service:</p>
+        <div class="code-block">
+          <span class="cmd">cd</span> dashboard<br>
+          <span class="cmd">./setup.sh</span>
+        </div>
+        <p>This will install npm packages, build the Vite frontend, and register VidClaw as a system service.</p>
+      </div>
+
+      <div class="step">
+        <h3>Access via SSH tunnel</h3>
+        <p>VidClaw binds to <code>localhost:3333</code> for security. Access it from your local machine:</p>
+        <div class="code-block">
+          <span class="cmd">ssh</span> -L 3333:localhost:3333 root@your-server
+        </div>
+        <p>Then open <a href="http://localhost:3333">http://localhost:3333</a> in your browser.</p>
+      </div>
+    </div>
+
+    <h2>AI Cost Tracking Configuration</h2>
+    <p>VidClaw automatically detects your OpenClaw usage data. The <a href="/features">AI cost tracking</a> panel reads from OpenClaw's usage logs and displays:</p>
+    <ul>
+      <li>Real-time token counts per model</li>
+      <li>Estimated costs based on current API pricing</li>
+      <li>Rate limit progress bars matching Anthropic's windows</li>
+    </ul>
+    <div class="note">
+      <p><strong>Tip:</strong> Switch models directly from the VidClaw navbar. Your agent will use the new model on its next session.</p>
+    </div>
+
+    <h2>Managing Tasks with the Kanban Board</h2>
+    <p>The Kanban board is VidClaw's primary interface for <strong>OpenClaw agent management</strong>. Tasks flow through four columns:</p>
+    <ol>
+      <li><strong>Backlog</strong> — ideas and future work</li>
+      <li><strong>Todo</strong> — queued for your agent</li>
+      <li><strong>In Progress</strong> — your agent is currently working on these</li>
+      <li><strong>Done</strong> — completed tasks with timestamps</li>
+    </ol>
+    <p>Drag cards between columns, assign priorities (P1–P4), and attach skills to tasks. Your agent picks up Todo items automatically based on priority.</p>
+
+    <h2>Soul Editor — Customize Your Agent</h2>
+    <p>The Soul Editor lets you shape your agent's personality and instructions. Edit the <code>SOUL.md</code> file through a visual interface with:</p>
+    <ul>
+      <li>Live preview of changes</li>
+      <li>Version history with one-click revert</li>
+      <li>Six starter templates (professional, casual, technical, etc.)</li>
+    </ul>
+
+    <h2>Skills Manager</h2>
+    <p>Skills extend your agent's capabilities. Through VidClaw's Skills Manager you can:</p>
+    <ul>
+      <li>Browse all bundled and custom skills</li>
+      <li>Enable or disable skills with a toggle</li>
+      <li>Create new custom skills with the built-in editor</li>
+    </ul>
+    <p>Changes take effect on your agent's next session — no restart required.</p>
+
+    <h2>Updating VidClaw</h2>
+    <div class="code-block">
+      <span class="cmd">cd</span> ~/.openclaw/workspace/dashboard<br>
+      <span class="cmd">./update.sh</span>
+    </div>
+    <p>The update script pulls the latest changes, rebuilds the frontend, and restarts the service.</p>
+
+    <h2>Uninstalling</h2>
+    <div class="code-block">
+      <span class="cmd">cd</span> ~/.openclaw/workspace/dashboard<br>
+      <span class="cmd">./uninstall.sh</span>
+    </div>
+    <p>This stops the service, removes the systemd unit, and cleans up. Your OpenClaw data is never touched.</p>
+
+    <div class="note">
+      <p><strong>Need help?</strong> Open an issue on <a href="https://github.com/madrzak/vidclaw/issues">GitHub</a> or check the <a href="/changelog">changelog</a> for recent updates.</p>
+    </div>
+  </div>
+
+  <footer>
+    <p>Built by <a href="https://x.com/woocassh">woocassh</a> · <a href="https://github.com/madrzak/vidclaw">GitHub</a> · <a href="/features">Features</a> · <a href="/docs">Docs</a> · <a href="/changelog">Changelog</a> · MIT License</p>
+  </footer>
+
+</body>
+</html>

--- a/docs/features/index.html
+++ b/docs/features/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Features - VidClaw | Self-Hosted AI Dashboard for OpenClaw</title>
+  <meta name="description" content="Explore VidClaw features: self-hosted AI dashboard, OpenClaw agent management, AI cost tracking, Kanban task board, skills manager, and soul editor.">
+  <link rel="canonical" href="https://vidclaw.com/features">
+  <script async src="https://plausible.io/js/pa-GKT997euCDfQROHoFG713.js"></script>
+  <script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()</script>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root { --bg: #0a0a0f; --surface: #12121a; --border: #1e1e2e; --text: #e4e4e7; --muted: #71717a; --accent: #f97316; --accent-glow: rgba(249, 115, 22, 0.15); }
+    html, body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); line-height: 1.6; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    nav { display: flex; align-items: center; justify-content: space-between; max-width: 1100px; margin: 0 auto; padding: 1.5rem 2rem; }
+    nav .brand { font-weight: 800; font-size: 1.2rem; color: var(--text); display: flex; align-items: center; gap: 0.5rem; }
+    nav .brand:hover { text-decoration: none; color: var(--accent); }
+    nav .nav-links { display: flex; gap: 1.5rem; font-size: 0.95rem; }
+    nav .nav-links a { color: var(--muted); }
+    nav .nav-links a:hover, nav .nav-links a.active { color: var(--accent); text-decoration: none; }
+
+    .page { max-width: 800px; margin: 0 auto; padding: 2rem 2rem 6rem; }
+    .page h1 { font-size: clamp(2rem, 5vw, 3rem); font-weight: 800; margin-bottom: 1rem; background: linear-gradient(135deg, #f97316, #fbbf24); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+    .page .subtitle { color: var(--muted); font-size: 1.15rem; margin-bottom: 3rem; }
+    .page h2 { font-size: 1.5rem; font-weight: 700; margin: 3rem 0 1rem; padding-top: 1rem; }
+    .page h3 { font-size: 1.15rem; font-weight: 600; margin: 1.5rem 0 0.5rem; }
+    .page p, .page li { color: var(--muted); font-size: 1rem; margin-bottom: 1rem; }
+    .page p strong { color: var(--text); }
+    .page ul { padding-left: 1.5rem; margin-bottom: 1.5rem; }
+    .page li { margin-bottom: 0.5rem; }
+
+    .card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; margin: 2rem 0; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 2rem; transition: border-color 0.2s, transform 0.2s; }
+    .card:hover { border-color: var(--accent); transform: translateY(-2px); }
+    .card-icon { font-size: 1.8rem; margin-bottom: 0.75rem; }
+    .card h3 { margin-top: 0; }
+
+    .cta-box { text-align: center; margin: 4rem 0 0; padding: 3rem 2rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; }
+    .cta-box p { color: var(--muted); margin-bottom: 1.5rem; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.85rem 2rem; border-radius: 8px; font-size: 1rem; font-weight: 600; transition: all 0.2s; border: none; cursor: pointer; }
+    .btn-primary { background: var(--accent); color: #fff; }
+    .btn-primary:hover { background: #ea580c; transform: translateY(-1px); box-shadow: 0 8px 30px rgba(249, 115, 22, 0.3); text-decoration: none; }
+
+    footer { text-align: center; padding: 3rem 2rem; color: var(--muted); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--accent); }
+  </style>
+</head>
+<body>
+
+  <nav>
+    <a href="/" class="brand">⚡ VidClaw</a>
+    <div class="nav-links">
+      <a href="/features" class="active">Features</a>
+      <a href="/docs">Docs</a>
+      <a href="/changelog">Changelog</a>
+      <a href="https://github.com/madrzak/vidclaw">GitHub</a>
+    </div>
+  </nav>
+
+  <div class="page">
+    <h1>Features</h1>
+    <p class="subtitle">Everything you need to manage your AI agent from one self-hosted dashboard. No cloud, no accounts, no tracking.</p>
+
+    <h2>Self-Hosted AI Dashboard</h2>
+    <p>VidClaw is a <strong>self-hosted AI dashboard</strong> that runs entirely on your own server. Unlike cloud-based alternatives, your data never leaves your machine. The dashboard binds to localhost and is accessed through an SSH tunnel — giving you a secure, private command center for your AI agent.</p>
+    <p>Built with React and Node.js, VidClaw is lightweight, fast, and designed for developers who prefer to own their infrastructure. No subscriptions, no vendor lock-in, no third-party dependencies.</p>
+
+    <h2>OpenClaw Agent Management</h2>
+    <p>VidClaw is purpose-built for <strong>OpenClaw agent management</strong>. It reads directly from your OpenClaw workspace, giving you a visual interface over everything your agent does.</p>
+
+    <div class="card-grid">
+      <div class="card">
+        <div class="card-icon">🗂️</div>
+        <h3>Kanban Task Board</h3>
+        <p>Drag-and-drop task management with Backlog, Todo, In Progress, and Done columns. Assign priorities and skills — your agent picks up tasks automatically.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">💜</div>
+        <h3>Soul Editor</h3>
+        <p>Edit your agent's persona, identity, and operating instructions. Version history with one-click revert. Six starter templates to choose from.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">🧩</div>
+        <h3>Skills Manager</h3>
+        <p>Browse, enable, disable, or create custom skills. Your agent loads changes automatically on the next session — no restart required.</p>
+      </div>
+      <div class="card">
+        <div class="card-icon">📁</div>
+        <h3>Content Browser</h3>
+        <p>Browse workspace files with markdown preview and syntax highlighting. See exactly what your agent has created, edited, or organized.</p>
+      </div>
+    </div>
+
+    <h2>AI Cost Tracking</h2>
+    <p><strong>AI cost tracking</strong> is built into VidClaw's core. Monitor real-time token usage and cost estimates across all your AI models. Visual progress bars match Anthropic's rate limit windows so you always know where you stand.</p>
+    <ul>
+      <li><strong>Per-model breakdown</strong> — see costs for Claude, GPT, and other models separately</li>
+      <li><strong>Daily and monthly summaries</strong> — track spending trends over time</li>
+      <li><strong>Rate limit awareness</strong> — progress bars show how close you are to limits</li>
+      <li><strong>Model switching</strong> — change models directly from the navbar</li>
+    </ul>
+
+    <h2>Activity Calendar & History</h2>
+    <p>A monthly calendar view shows what your agent has been working on each day. Data is parsed from memory files and task completion history, giving you a bird's-eye view of your agent's productivity.</p>
+
+    <h2>Privacy & Security First</h2>
+    <p>VidClaw is <strong>100% self-hosted</strong> with zero cloud dependencies. The dashboard only binds to <code>localhost</code> — you access it through an SSH tunnel. No accounts, no analytics (except optional Plausible), no data collection. Your agent's data stays on your server.</p>
+
+    <div class="cta-box">
+      <p>Ready to take control of your AI agent?</p>
+      <a href="/docs" class="btn btn-primary">Get Started →</a>
+    </div>
+  </div>
+
+  <footer>
+    <p>Built by <a href="https://x.com/woocassh">woocassh</a> · <a href="https://github.com/madrzak/vidclaw">GitHub</a> · <a href="/features">Features</a> · <a href="/docs">Docs</a> · <a href="/changelog">Changelog</a> · MIT License</p>
+  </footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -356,6 +356,16 @@
 </head>
 <body>
 
+  <nav style="display:flex;align-items:center;justify-content:space-between;max-width:1100px;margin:0 auto;padding:1.5rem 2rem;">
+    <a href="/" style="font-weight:800;font-size:1.2rem;color:var(--text);display:flex;align-items:center;gap:0.5rem;text-decoration:none;">⚡ VidClaw</a>
+    <div style="display:flex;gap:1.5rem;font-size:0.95rem;">
+      <a href="/features" style="color:var(--muted);text-decoration:none;">Features</a>
+      <a href="/docs" style="color:var(--muted);text-decoration:none;">Docs</a>
+      <a href="/changelog" style="color:var(--muted);text-decoration:none;">Changelog</a>
+      <a href="https://github.com/madrzak/vidclaw" style="color:var(--muted);text-decoration:none;">GitHub</a>
+    </div>
+  </nav>
+
   <div class="ph-badge">
     <a href="https://www.producthunt.com/products/vidclaw?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-vidclaw" target="_blank" rel="noopener noreferrer"><img alt="VidClaw - An open-source, self-hosted Kanban for your OpenClaw agent. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1080264&amp;theme=light&amp;t=1771254815882"></a>
   </div>
@@ -459,7 +469,7 @@
   </div>
 
   <footer>
-    <p>Built by <a href="https://x.com/woocassh">woocassh</a> · <a href="https://github.com/madrzak/vidclaw">GitHub</a> · MIT License</p>
+    <p>Built by <a href="https://x.com/woocassh">woocassh</a> · <a href="https://github.com/madrzak/vidclaw">GitHub</a> · <a href="/features">Features</a> · <a href="/docs">Docs</a> · <a href="/changelog">Changelog</a> · MIT License</p>
   </footer>
 
 </body>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,22 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://vidclaw.com/</loc>
-    <lastmod>2026-02-17</lastmod>
+    <lastmod>2026-02-18</lastmod>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://vidclaw.com/features</loc>
+    <lastmod>2026-02-18</lastmod>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://vidclaw.com/docs</loc>
+    <lastmod>2026-02-18</lastmod>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://vidclaw.com/changelog</loc>
+    <lastmod>2026-02-18</lastmod>
+    <priority>0.7</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Adds three new pages to the GitHub Pages site for SEO and user experience:

- **`/features`** — keyword-rich feature overview targeting "self-hosted AI dashboard", "OpenClaw agent management", "AI cost tracking"
- **`/docs`** — complete setup guide with step-by-step instructions
- **`/changelog`** — release history with version timeline

## Changes

- Created `docs/features/index.html`, `docs/docs/index.html`, `docs/changelog/index.html`
- Added navigation bar to homepage and all new pages
- Updated footer with internal links across all pages
- Updated `sitemap.xml` with new URLs
- All pages match existing dark theme with orange accent