### PR TITLE
fix: shellcheck SC2034 — unused variable in service.sh

### DIFF
--- a/scripts/lib/service.sh
+++ b/scripts/lib/service.sh
@@ -365,8 +365,8 @@ stop_direct_service() {
   fi
 
   kill "${pid}" >/dev/null 2>&1 || true
-  local attempt
-  for attempt in 1 2 3 4 5; do
+  local _attempt
+  for _attempt in 1 2 3 4 5; do
     if ! kill -0 "${pid}" >/dev/null 2>&1; then
       break
     fi


### PR DESCRIPTION
Renames `attempt` to `_attempt` in the process-kill retry loop. Variable is only used as a loop counter and never referenced in the body, triggering SC2034. Fixes CI failure.