### PR TITLE
feat: file browser write/delete with security hardening

### DIFF
--- a/server/controllers/files.js
+++ b/server/controllers/files.js
@@ -75,3 +75,59 @@ export function getWorkspaceFileHistory(req, res) {
   if (!name || name.includes('/') || name.includes('..')) return res.status(400).json({ error: 'Invalid name' });
   res.json(readHistoryFile(path.join(__dirname, 'data', `${name}-history.json`)));
 }
+
+// Validate path is within workspace (handles trailing slash edge case)
+function isPathWithinWorkspace(fullPath) {
+  const resolvedWorkspace = path.resolve(WORKSPACE) + path.sep;
+  const resolvedPath = path.resolve(fullPath);
+  return resolvedPath.startsWith(resolvedWorkspace) || resolvedPath === path.resolve(WORKSPACE);
+}
+
+export function putFileContent(req, res) {
+  const reqPath = req.body.path;
+  if (!reqPath) return res.status(400).json({ error: 'Path required' });
+  const fullPath = path.resolve(WORKSPACE, reqPath);
+  if (!isPathWithinWorkspace(fullPath)) return res.status(403).json({ error: 'Forbidden' });
+  try {
+    const safeName = reqPath.replace(/\//g, '_');
+    const histPath = path.join(__dirname, 'data', `${safeName}-history.json`);
+    if (fs.existsSync(fullPath)) {
+      const old = fs.readFileSync(fullPath, 'utf-8');
+      if (old) appendHistory(histPath, old);
+    }
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, req.body.content);
+    res.json({ success: true });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+}
+
+export function deleteFile(req, res) {
+  const reqPath = req.query.path;
+  if (!reqPath) return res.status(400).json({ error: 'Path required' });
+  const fullPath = path.resolve(WORKSPACE, reqPath);
+
+  // Security: validate path is within workspace
+  if (!isPathWithinWorkspace(fullPath)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
+  // Security: disallow deleting the workspace root
+  if (path.resolve(fullPath) === path.resolve(WORKSPACE)) {
+    return res.status(403).json({ error: 'Cannot delete workspace root' });
+  }
+
+  try {
+    const stat = fs.statSync(fullPath);
+    if (stat.isDirectory()) {
+      // For directories, use recursive delete but log the action
+      const entries = fs.readdirSync(fullPath);
+      if (entries.length > 0) {
+        console.log(`[deleteFile] Recursively deleting directory with ${entries.length} entries: ${reqPath}`);
+      }
+      fs.rmSync(fullPath, { recursive: true });
+    } else {
+      fs.unlinkSync(fullPath);
+    }
+    res.json({ success: true });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+}

--- a/server/routes.js
+++ b/server/routes.js
@@ -12,7 +12,7 @@ import { getUsage } from './controllers/usage.js';
 import { getOpenclawVersion, updateOpenclaw } from './controllers/openclaw.js';
 import { listModels, setModel, getHeartbeat, postHeartbeat } from './controllers/models.js';
 import { listSkills, toggleSkill, createSkill, getSkillContent, deleteSkill } from './controllers/skills.js';
-import { listFiles, getFileContent, downloadFile, getWorkspaceFile, putWorkspaceFile, getWorkspaceFileHistory } from './controllers/files.js';
+import { listFiles, getFileContent, downloadFile, getWorkspaceFile, putWorkspaceFile, getWorkspaceFileHistory, putFileContent, deleteFile } from './controllers/files.js';
 import { getSoul, putSoul, getSoulHistory, revertSoul, getSoulTemplates } from './controllers/soul.js';
 import { getSettings, postSettings } from './controllers/settings.js';
 import { getVidclawVersion, updateVidclaw } from './controllers/vidclaw.js';
@@ -65,6 +65,8 @@ router.get('/api/files/download', downloadFile);
 router.get('/api/workspace-file', getWorkspaceFile);
 router.put('/api/workspace-file', putWorkspaceFile);
 router.get('/api/workspace-file/history', getWorkspaceFileHistory);
+router.put('/api/files/content', putFileContent);
+router.delete('/api/files', deleteFile);
 
 // Soul
 router.get('/api/soul', getSoul);

--- a/src/components/Content/FileBrowser.jsx
+++ b/src/components/Content/FileBrowser.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useMemo } from 'react'
-import { Folder, File, ChevronRight, ArrowLeft, Download, Eye, ArrowUpDown, FileText, FileImage, FileVideo, FileAudio, FileCode, FileArchive } from 'lucide-react'
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { Folder, File, ChevronRight, ArrowLeft, Download, Eye, Pencil, Search, X, Trash2, ArrowUpDown, FileText, FileImage, FileVideo, FileAudio, FileCode, FileArchive } from 'lucide-react'
 import FilePreview from './FilePreview'
 import { cn } from '@/lib/utils'
 
@@ -50,11 +50,34 @@ function formatDate(iso) {
   return d.toLocaleDateString('en-IE', { day: 'numeric', month: 'short', year: d.getFullYear() !== now.getFullYear() ? 'numeric' : undefined })
 }
 
+function fuzzyMatch(pattern, text) {
+  const p = pattern.toLowerCase()
+  const t = text.toLowerCase()
+  let pi = 0
+  let score = 0
+  let prevMatch = -1
+  for (let ti = 0; ti < t.length && pi < p.length; ti++) {
+    if (t[ti] === p[pi]) {
+      score += (prevMatch === ti - 1) ? 2 : 1
+      prevMatch = ti
+      pi++
+    }
+  }
+  return pi === p.length ? score : -1
+}
+
 export default function FileBrowser() {
   const [currentPath, setCurrentPath] = useState('')
   const [entries, setEntries] = useState([])
   const [preview, setPreview] = useState(null)
   const [sortBy, setSortBy] = useState('name-asc')
+  const [fuzzyFilter, setFuzzyFilter] = useState('')
+  const [fileContent, setFileContent] = useState(null)
+  const [editContent, setEditContent] = useState('')
+  const [editing, setEditing] = useState(false)
+  const [saveStatus, setSaveStatus] = useState('')
+  const [ctxMenu, setCtxMenu] = useState(null)
+  const saveTimerRef = useRef(null)
 
   useEffect(() => {
     fetch(`/api/files?path=${encodeURIComponent(currentPath)}`)
@@ -63,28 +86,68 @@ export default function FileBrowser() {
       .catch(() => setEntries([]))
   }, [currentPath])
 
-  const sortedEntries = useMemo(() => {
-    const dirs = entries.filter(e => e.isDirectory)
-    const files = entries.filter(e => !e.isDirectory)
-    const [field, dir] = sortBy.split('-')
-    const mul = dir === 'asc' ? 1 : -1
+  // Close context menu on click anywhere
+  useEffect(() => {
+    if (!ctxMenu) return
+    const close = () => setCtxMenu(null)
+    window.addEventListener('click', close)
+    return () => window.removeEventListener('click', close)
+  }, [ctxMenu])
 
-    const sorter = (a, b) => {
-      if (field === 'name') return mul * a.name.localeCompare(b.name)
-      if (field === 'date') return mul * ((a.mtime || '').localeCompare(b.mtime || ''))
-      if (field === 'size') return mul * ((a.size || 0) - (b.size || 0))
-      return 0
+  const sortedAndFiltered = useMemo(() => {
+    let result = entries
+
+    // Apply fuzzy filter first
+    if (fuzzyFilter) {
+      result = result
+        .map(e => ({ ...e, score: fuzzyMatch(fuzzyFilter, e.name) }))
+        .filter(e => e.score > 0)
+        .sort((a, b) => b.score - a.score)
+    } else {
+      // Apply sorting when not filtering
+      const dirs = result.filter(e => e.isDirectory)
+      const files = result.filter(e => !e.isDirectory)
+      const [field, dir] = sortBy.split('-')
+      const mul = dir === 'asc' ? 1 : -1
+
+      const sorter = (a, b) => {
+        if (field === 'name') return mul * a.name.localeCompare(b.name)
+        if (field === 'date') return mul * ((a.mtime || '').localeCompare(b.mtime || ''))
+        if (field === 'size') return mul * ((a.size || 0) - (b.size || 0))
+        return 0
+      }
+
+      result = [...dirs.sort(sorter), ...files.sort(sorter)]
     }
 
-    return [...dirs.sort(sorter), ...files.sort(sorter)]
-  }, [entries, sortBy])
+    return result
+  }, [entries, sortBy, fuzzyFilter])
+
+  function fetchFileContent(filePath) {
+    fetch(`/api/files/content?path=${encodeURIComponent(filePath)}`)
+      .then(r => r.json())
+      .then(d => {
+        setFileContent(d.content)
+        setEditContent(d.content)
+      })
+      .catch(() => {
+        setFileContent('Failed to load file')
+        setEditContent('')
+      })
+  }
 
   function navigate(entry) {
     if (entry.isDirectory) {
       setCurrentPath(entry.path)
       setPreview(null)
+      setFileContent(null)
+      setEditing(false)
+      setSaveStatus('')
     } else {
       setPreview(entry.path)
+      setEditing(false)
+      setSaveStatus('')
+      fetchFileContent(entry.path)
     }
   }
 
@@ -93,6 +156,55 @@ export default function FileBrowser() {
     parts.pop()
     setCurrentPath(parts.join('/'))
     setPreview(null)
+    setFileContent(null)
+    setEditing(false)
+  }
+
+  const scheduleAutosave = useCallback((content, filePath) => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+    setSaveStatus('saving')
+    saveTimerRef.current = setTimeout(() => {
+      fetch('/api/files/content', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: filePath, content }),
+      })
+        .then(r => r.json())
+        .then(() => {
+          setSaveStatus('saved')
+          setFileContent(content)
+          setTimeout(() => setSaveStatus(s => s === 'saved' ? '' : s), 2000)
+        })
+        .catch(() => setSaveStatus(''))
+    }, 1500)
+  }, [])
+
+  function handleEditChange(e) {
+    const val = e.target.value
+    setEditContent(val)
+    scheduleAutosave(val, preview)
+  }
+
+  function handleDelete(entry) {
+    if (!confirm(`Delete "${entry.name}"${entry.isDirectory ? ' and all its contents' : ''}?`)) return
+    fetch(`/api/files?path=${encodeURIComponent(entry.path)}`, { method: 'DELETE' })
+      .then(r => r.json())
+      .then(d => {
+        if (d.success) {
+          setEntries(prev => prev.filter(e => e.path !== entry.path))
+          if (preview === entry.path) {
+            setPreview(null)
+            setFileContent(null)
+            setEditing(false)
+          }
+        }
+      })
+      .catch(() => {})
+  }
+
+  function handleContextMenu(e, entry) {
+    e.preventDefault()
+    setCtxMenu({ x: e.clientX, y: e.clientY, entry })
   }
 
   const breadcrumbs = currentPath ? currentPath.split('/') : []
@@ -131,12 +243,34 @@ export default function FileBrowser() {
             </select>
           </div>
         </div>
+
+        {/* Fuzzy filter */}
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+          <Search size={14} className="text-muted-foreground shrink-0" />
+          <input
+            type="text"
+            value={fuzzyFilter}
+            onChange={e => setFuzzyFilter(e.target.value)}
+            placeholder="Filter files..."
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+          {fuzzyFilter && (
+            <button onClick={() => setFuzzyFilter('')} className="text-muted-foreground hover:text-foreground">
+              <X size={14} />
+            </button>
+          )}
+        </div>
+
         <div className="flex-1 overflow-y-auto divide-y divide-border">
-          {sortedEntries.map(entry => (
+          {sortedAndFiltered.map(entry => (
             <div
               key={entry.path}
-              className="flex items-center gap-3 px-3 py-2 hover:bg-accent/50 cursor-pointer transition-colors group"
+              className={cn(
+                'flex items-center gap-3 px-3 py-2 hover:bg-accent/50 cursor-pointer transition-colors group',
+                preview === entry.path && 'bg-accent/50'
+              )}
               onClick={() => navigate(entry)}
+              onContextMenu={e => handleContextMenu(e, entry)}
             >
               {entry.isDirectory ? (
                 <Folder size={16} className="text-amber-400 shrink-0" />
@@ -164,8 +298,10 @@ export default function FileBrowser() {
               )}
             </div>
           ))}
-          {entries.length === 0 && (
-            <div className="p-4 text-sm text-muted-foreground text-center">Empty directory</div>
+          {sortedAndFiltered.length === 0 && (
+            <div className="p-4 text-sm text-muted-foreground text-center">
+              {fuzzyFilter ? 'No matches' : 'Empty directory'}
+            </div>
           )}
         </div>
       </div>
@@ -174,16 +310,53 @@ export default function FileBrowser() {
         <div className="flex-1 border border-border rounded-xl bg-card/50 overflow-hidden flex flex-col">
           <div className="flex items-center justify-between p-3 border-b border-border">
             <span className="text-sm font-medium truncate">{preview.split('/').pop()}</span>
-            <div className="flex gap-2">
+            <div className="flex items-center gap-2">
+              {saveStatus === 'saving' && <span className="text-xs text-muted-foreground">Saving...</span>}
+              {saveStatus === 'saved' && <span className="text-xs text-green-400">Saved</span>}
+              <button
+                onClick={() => { setEditing(!editing); setSaveStatus('') }}
+                className="text-muted-foreground hover:text-foreground"
+                title={editing ? 'Preview' : 'Edit'}
+              >
+                {editing ? <Eye size={14} /> : <Pencil size={14} />}
+              </button>
               <a href={`/api/files/download?path=${encodeURIComponent(preview)}`} className="text-muted-foreground hover:text-foreground">
                 <Download size={14} />
               </a>
-              <button onClick={() => setPreview(null)} className="text-muted-foreground hover:text-foreground text-xs">✕</button>
+              <button onClick={() => { setPreview(null); setFileContent(null); setEditing(false); setSaveStatus('') }} className="text-muted-foreground hover:text-foreground text-xs">
+                ✕
+              </button>
             </div>
           </div>
           <div className="flex-1 overflow-auto">
-            <FilePreview path={preview} />
+            {editing ? (
+              <textarea
+                value={editContent}
+                onChange={handleEditChange}
+                className="w-full h-full p-4 bg-transparent text-sm font-mono resize-none outline-none"
+                spellCheck={false}
+              />
+            ) : fileContent === null ? (
+              <div className="p-4 text-sm text-muted-foreground">Loading...</div>
+            ) : (
+              <FilePreview path={preview} content={fileContent} />
+            )}
           </div>
+        </div>
+      )}
+
+      {/* Right-click context menu */}
+      {ctxMenu && (
+        <div
+          className="fixed z-50 bg-popover border border-border rounded-lg shadow-lg py-1 min-w-[140px]"
+          style={{ left: ctxMenu.x, top: ctxMenu.y }}
+        >
+          <button
+            onClick={() => { handleDelete(ctxMenu.entry); setCtxMenu(null) }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-sm text-red-400 hover:bg-accent/50 transition-colors"
+          >
+            <Trash2 size={14} /> Delete
+          </button>
         </div>
       )}
     </div>

--- a/src/components/Content/FilePreview.jsx
+++ b/src/components/Content/FilePreview.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import ReactMarkdown from 'react-markdown'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
@@ -9,19 +9,10 @@ const extToLang = {
   css: 'css', html: 'html', md: 'markdown',
 }
 
-export default function FilePreview({ path }) {
-  const [content, setContent] = useState(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    setLoading(true)
-    fetch(`/api/files/content?path=${encodeURIComponent(path)}`)
-      .then(r => r.json())
-      .then(d => { setContent(d.content); setLoading(false) })
-      .catch(() => { setContent('Failed to load file'); setLoading(false) })
-  }, [path])
-
-  if (loading) return <div className="p-4 text-sm text-muted-foreground">Loading...</div>
+export default function FilePreview({ path, content }) {
+  if (content === null || content === undefined) {
+    return <div className="p-4 text-sm text-muted-foreground">Loading...</div>
+  }
 
   const ext = path.split('.').pop().toLowerCase()
   const isMarkdown = ext === 'md'


### PR DESCRIPTION
## Summary

Addresses security concerns from PR #35 review and adds file write/delete capabilities to the file browser.

### Security fixes (per review feedback)
- **Path traversal protection**: Uses `path.resolve()` with trailing separator check instead of simple `startsWith()`
- **Workspace root protection**: Explicitly blocks deletion of workspace root directory
- **Recursive delete logging**: Logs when directories with contents are deleted
- **Enhanced confirmation**: Delete prompt specifies "and all its contents" for directories

### New endpoints
- `PUT /api/files/content` — write file content with history tracking
- `DELETE /api/files` — delete file or directory

### FileBrowser improvements
- Inline file editing with edit/preview toggle (pencil/eye icons)
- Autosave with 1.5s debounce after last keystroke
- Save status indicator ("Saving..." / "Saved")
- Right-click context menu for file deletion
- Fuzzy filename filtering with consecutive-character scoring
- Active file highlight in file list
- FilePreview now accepts content as prop (FileBrowser owns content state)

## Files changed (4 files)
- `server/controllers/files.js` — new endpoints + security hardening
- `server/routes.js` — registered new routes
- `src/components/Content/FileBrowser.jsx` — editing, autosave, delete, fuzzy filter
- `src/components/Content/FilePreview.jsx` — accepts content prop

## Test plan
- [ ] `npm run build` — clean compile
- [ ] Type partial filename in filter — verify real-time fuzzy matching
- [ ] Click file — verify preview renders correctly
- [ ] Click pencil icon — verify textarea with raw content
- [ ] Edit text, wait 1.5s — verify "Saved" indicator appears
- [ ] Toggle back to preview — verify changes persisted
- [ ] Right-click file — verify delete context menu appears
- [ ] Delete file — verify removed from list and preview closes
- [ ] Attempt path traversal (e.g., `../../../etc/passwd`) — verify 403 Forbidden
- [ ] Download button still works on hover

---

## Follow-up PRs (splitting original PR #35)

This is **PR 1 of 3** from the original PR #35, split per review request:

1. **This PR**: File browser write/delete ✅
2. **Next: `feat/terminal-emulation`** — Terminal emulation with node-pty + xterm.js (the main feature). Will address:
   - Migrate to `@xterm/xterm` and `@xterm/addon-fit` (deprecated packages)
   - WebSocket streaming instead of 200ms polling
   - Consider making node-pty optional to avoid native module build complexity
3. **Later: `feat/ui-polish`** — GSAP animations, typography, visual effects. Will address:
   - Self-host fonts or make Google Fonts optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)