### PR TITLE
fix: Esc closes modals + bulk delete done tasks

### DIFF
--- a/src/components/Credentials/CredentialsManager.jsx
+++ b/src/components/Credentials/CredentialsManager.jsx
@@ -7,6 +7,12 @@ const API = '/api/credentials'
 const ACCEPTED_EXTENSIONS = '.json,.pem,.key,.p12,.pfx,.crt,.cert'
 
 function Modal({ title, onClose, children }) {
+  React.useEffect(() => {
+    const handleKey = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
       <div className="bg-card border border-border rounded-t-xl sm:rounded-lg w-full max-w-md p-4 sm:p-6 space-y-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>

--- a/src/components/Kanban/Board.jsx
+++ b/src/components/Kanban/Board.jsx
@@ -198,7 +198,7 @@ export default function Board() {
   }
 
   async function handleBulkArchive(status) {
-    await fetch('/api/tasks/bulk-archive', {
+    await fetch('/api/tasks/bulk-delete', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ status }),

--- a/src/components/Kanban/TaskDetailDialog.jsx
+++ b/src/components/Kanban/TaskDetailDialog.jsx
@@ -107,6 +107,13 @@ export default function TaskDetailDialog({ open, onClose, task }) {
     return () => clearInterval(id)
   }, [open, task?.id, task?.status, task?.startedAt])
 
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
   if (!open || !task) return null
 
   const isDone = task.status === 'done'

--- a/src/components/Kanban/TaskDialog.jsx
+++ b/src/components/Kanban/TaskDialog.jsx
@@ -225,6 +225,13 @@ export default function TaskDialog({ open, onClose, onSave, onDelete, task }) {
     }
   }, [task, open])
 
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
   if (!open) return null
 
   function handleSave() {

--- a/src/components/Skills/SkillsManager.jsx
+++ b/src/components/Skills/SkillsManager.jsx
@@ -44,6 +44,11 @@ function SourceBadge({ source }) {
 }
 
 function CreateModal({ onClose, onCreated }) {
+  React.useEffect(() => {
+    const handleKey = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [instructions, setInstructions] = useState('')


### PR DESCRIPTION
- **#43**: Escape key now closes all modals (TaskDialog, TaskDetailDialog, Credentials, Skills)
- **#44**: Bulk delete button was calling `/api/tasks/bulk-archive` but backend route is `/api/tasks/bulk-delete`

Closes #43, closes #44