### PR TITLE
fix install script without tailscale

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ fi
 step "Running setup..."
 echo
 chmod +x setup.sh
-./setup.sh "${SETUP_ARGS[@]}"
+./setup.sh "${SETUP_ARGS[@]+"${SETUP_ARGS[@]}"}"
 
 # ---------- done ----------
 echo


### PR DESCRIPTION
Running `bash install.sh --no-tailscale` (or any invocation that results  in an empty `SETUP_ARGS` array) fails with:

      install.sh: line 121: SETUP_ARGS[@]: unbound variable

  This is caused by `set -u` treating an empty array's `[@]` expansion as  unbound — a known bash quirk.

  ## Fix

  Use the `${var+word}` conditional expansion pattern on line 121, which
  only expands the array when it has elements and produces nothing when it
  is empty:

      ./setup.sh "${SETUP_ARGS[@]+"${SETUP_ARGS[@]}"}"

  This is the same pattern already used on line 100 for the `filtered`
  array.